### PR TITLE
Update contributes.languages definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,8 @@
                 ],
                 "filenames": [
                     "BUILD",
+                    "BUILD.bazel",
                     "WORKSPACE"
-                ],
-                "filenamePatterns": [
-                    "BUILD.*"
                 ],
                 "aliases": [
                     "Bazel"


### PR DESCRIPTION
The use of "BUILD.*" as filenamePatterns value includes unwanted files such `build.go` (especially on case-insensitive file-systems).