### PR TITLE
Adding support for *.BUILD files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
             {
                 "id": "bazel",
                 "extensions": [
-                    ".bzl"
+                    ".bzl",
+                    ".BUILD"
                 ],
                 "filenames": [
                     "BUILD",


### PR DESCRIPTION
Another pattern for bazel build files is <package>.BUILD as can be seen commonly in the TensorFlow repository