### PR TITLE
Fix the snippet of `cc_library`

### DIFF
--- a/snippets/bazel.json
+++ b/snippets/bazel.json
@@ -48,7 +48,7 @@
 			"\tname = \"${1:rule unique name}\",",
 			"\tsrcs = [\"${2:source files}\"],",
 			"\thdrs = [\"${3:header files}\"],",
-			"\tdeps = [\"${3:libraries to be linked}\"],",
+			"\tdeps = [\"${4:libraries to be linked}\"],",
 			")"
 		],
 		"description": "c/c++ library target"


### PR DESCRIPTION
When snippetting `cc_library`, `deps` needs its own index, otherwise, the hint "libraries to be linked" will not be show